### PR TITLE
Julia v0.6 Compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ os:
   - linux
   - osx
 julia:
-  - 0.4
+  - 0.5
+  - 0.6
   - nightly
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ julia:
   - 0.6
 notifications:
   email: false
-install: travis_wait mvn install
 # uncomment the following lines to override the default test script
 #script:
 #  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ julia:
   - 0.6
 notifications:
   email: false
+install: travis_wait mvn install
 # uncomment the following lines to override the default test script
 #script:
 #  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ os:
 julia:
   - 0.5
   - 0.6
-  - nightly
 notifications:
   email: false
 # uncomment the following lines to override the default test script

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.6
+julia 0.5
 SuffixArrays
 WaveletMatrices
 IndexableBitVectors

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.4
+julia 0.6
 SuffixArrays
 WaveletMatrices
 IndexableBitVectors

--- a/src/FMIndexes.jl
+++ b/src/FMIndexes.jl
@@ -79,11 +79,11 @@ function FMIndex(seq, σ=256; r=32, program=:SuffixArrays, mmap::Bool=false, opt
 end
 
 """
-    FMIndex(text::ASCIIString; opts...)
+    FMIndex(text::String; opts...)
 
 Build an FM-Index from an ASCII text.
 """
-function FMIndex(text::ASCIIString; opts...)
+function FMIndex(text::String; opts...)
     return FMIndex(convert(Vector{UInt8}, text), 128; opts...)
 end
 

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,1 +1,2 @@
 FactCheck
+Combinatorics

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using FMIndexes
 using FactCheck
+using Combinatorics
 
 srand(12345)
 
@@ -259,13 +260,13 @@ facts("full-text search") do
     function linear_search(query)
         locs = Int[]
         loc = 0
-        while (loc = searchindex(text, query, loc + 1)) > 0
+        while (loc = searchindex(text, Vector{UInt8}(query), loc + 1)) > 0
             push!(locs, loc)
         end
         return locs
     end
 
-    text = open(readall, Pkg.dir("FMIndexes", "test", "lorem_ipsum.txt"))
+    text = open(read, Pkg.dir("FMIndexes", "test", "lorem_ipsum.txt"))
     index = FMIndex(text, r=2)
 
     @fact count("Lorem", index) --> 1
@@ -282,5 +283,5 @@ facts("full-text search") do
         @fact locateall(query, index) |> sort --> locs
     end
 
-    @fact bytestring(restore(index)) --> text
+    @fact String(restore(index)) --> String(text)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -285,4 +285,3 @@ facts("full-text search") do
 
     @fact String(restore(index)) --> String(text)
 end
-

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -94,7 +94,7 @@ facts("restore") do
         @fact restore(index) --> seq
 
         σ = 128
-        seq = "abracadabra".data
+        seq = Vector{UInt8}("abracadabra")
         index = FMIndex(seq, σ)
         @fact restore(index) --> seq
     end
@@ -110,8 +110,8 @@ facts("restore") do
         σ = 128
         for n in [2, 15, 100], _ in 1:100
             seq = randstring(n)
-            index = FMIndex(seq.data, σ)
-            @fact restore(index) --> seq.data
+            index = FMIndex(Vector{UInt8}(seq), σ)
+            @fact restore(index) --> Vector{UInt8}(seq)
         end
     end
 end
@@ -126,7 +126,7 @@ facts("count") do
 
     context("\"abracadabra\"") do
         σ = 128
-        seq = "abracadabra".data
+        seq = Vector{UInt8}("abracadabra")
         index = FMIndex(seq, σ)
 
         @fact count("a", index) --> 5
@@ -196,7 +196,7 @@ facts("locate/locateall") do
 
     context("\"abracadabra\"") do
         σ = 128
-        seq = "abracadabra".data
+        seq = Vector{UInt8}("abracadabra")
         index = FMIndex(seq, σ)
 
         @fact locate("a", index) |> collect |> sort --> [1, 4, 6, 8, 11]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -285,3 +285,4 @@ facts("full-text search") do
 
     @fact String(restore(index)) --> String(text)
 end
+


### PR DESCRIPTION
This PR replaces ASCIIStrings with String throughout FMIndexes.jl, which should still be compatible with both v0.5 and v0.6.
The majority of changes in the PR alter String .data access handling in runtests.jl for compatibility with Julia v0.5/v0.6. 

Tests pass on my osx machine on v0.6 (*with* WaveletMatrices.jl on 437c127):
```
julia> Pkg.test("FMIndexes")
INFO: Computing test dependencies for FMIndexes...
INFO: No packages to install, update or remove
INFO: Testing FMIndexes

WARNING: deprecated syntax "abstract Result" at /Users/timsw/.julia/v0.6/FactCheck/src/FactCheck.jl:46.
Use "abstract type Result end" instead.
construct
  > one
  > short
  > long
  > dna
  > boundaries
  > mmap
  > use pSAscan
Out of 8 total facts:
  Verified: 7
  Pending:  1
restore
  > examples
  > dna
  > random
305 facts verified.
count
  > [0x00]
  > "abracadabra"
  > [0x00, 0x00, 0x01, 0x01]
29 facts verified.
locate/locateall
  > [0x00]
  > "abracadabra"
  > random
  > boundaries
113 facts verified.
full-text search
23 facts verified.
INFO: FMIndexes tests passed
```