### PR TITLE
do not import methods from base

### DIFF
--- a/src/FMIndexes.jl
+++ b/src/FMIndexes.jl
@@ -9,14 +9,6 @@ export
     locate,
     locateall
 
-import Base:
-    count,
-    length,
-    show,
-    start,
-    done,
-    next
-
 using SuffixArrays
 using WaveletMatrices
 using IndexableBitVectors
@@ -87,9 +79,9 @@ function FMIndex(text::String; opts...)
     return FMIndex(convert(Vector{UInt8}, text), 128; opts...)
 end
 
-length(index::FMIndex) = length(index.bwt)
+Base.length(index::FMIndex) = length(index.bwt)
 
-function show{w,T}(io::IO, fmindex::FMIndex{w,T})
+function Base.show{w,T}(io::IO, fmindex::FMIndex{w,T})
     print(io, "FMIndex{", w, ",", T, "}:\n")
     totalsize = (
         sizeof(fmindex.bwt) +
@@ -119,7 +111,7 @@ end
 """
 Count the number of occurrences of the given query.
 """
-function count(query, index::FMIndex)
+function Base.count(query, index::FMIndex)
     return length(sa_range(query, index))
 end
 

--- a/src/FMIndexes.jl
+++ b/src/FMIndexes.jl
@@ -82,7 +82,7 @@ end
 Base.length(index::FMIndex) = length(index.bwt)
 
 function Base.show{w,T}(io::IO, fmindex::FMIndex{w,T})
-    print(io, "FMIndex{", w, ",", T, "}:\n")
+    println(io, summary(fmindex), ':')
     totalsize = (
         sizeof(fmindex.bwt) +
         sizeof(fmindex.samples) +

--- a/src/lociter.jl
+++ b/src/lociter.jl
@@ -3,7 +3,7 @@ immutable LocationIterator{w,T}
     index::FMIndex{w,T}
 end
 
-length(iter::LocationIterator) = length(iter.range)
-@inline start(iter::LocationIterator) = 1
-@inline done(iter::LocationIterator, i) = i > length(iter)
-@inline next(iter::LocationIterator, i) = sa_value(iter.range[i], iter.index) + 1, i + 1
+Base.length(iter::LocationIterator) = length(iter.range)
+@inline Base.start(iter::LocationIterator) = 1
+@inline Base.done(iter::LocationIterator, i) = i > length(iter)
+@inline Base.next(iter::LocationIterator, i) = sa_value(iter.range[i], iter.index) + 1, i + 1


### PR DESCRIPTION
This is mainly for readability. Directly extending methods looks a little bit verbose but checking all imported methods is disruptive.