### PR TITLE
Fix constructor for String

### DIFF
--- a/src/FMIndexes.jl
+++ b/src/FMIndexes.jl
@@ -72,12 +72,12 @@ function FMIndex(seq, σ=256; r=32, program=:SuffixArrays, mmap::Bool=false, opt
 end
 
 """
-    FMIndex(text::String; opts...)
+    FMIndex(text; opts...)
 
 Build an FM-Index from an ASCII text.
 """
-function FMIndex(text::String; opts...)
-    return FMIndex(convert(Vector{UInt8}, text), 128; opts...)
+function FMIndex(text::Union{String, SubString{String}}; opts...)
+    return FMIndex(codeunits(text), 128; opts...)
 end
 
 Base.length(index::FMIndex) = length(index.bwt)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -129,7 +129,7 @@ end
 
     @testset "\"abracadabra\"" begin
         σ = 128
-        seq = Vector{UInt8}("abracadabra")
+        seq = "abracadabra"
         index = FMIndex(seq, σ)
 
         @test count("a", index) == 5
@@ -270,7 +270,7 @@ end
 
     text = read(joinpath(dirname(@__FILE__), "lorem_ipsum.txt"))
     textstr = String(copy(text))
-    index = FMIndex(text, r=2)
+    index = FMIndex(textstr, r=2)
     @test count("Lorem", index) == 1
     @test locateall("Lorem", index) == [1]
     @test count("hoge", index) == 0


### PR DESCRIPTION
Fix constructor for `String` by removing the outdated `convert` method that errors on Julia 1.0.